### PR TITLE
moved array declaration inside loop to avoid same referencing to fix …

### DIFF
--- a/ios/GoogleCast.m
+++ b/ios/GoogleCast.m
@@ -128,8 +128,8 @@ RCT_REMAP_METHOD(getDevices,
                  reject:(RCTPromiseRejectBlock)reject)
 {
   NSMutableArray *devicesList = [[NSMutableArray alloc] init];
-  NSMutableDictionary *singleDevice= [[NSMutableDictionary alloc] init];
   for (NSString *key in [self.currentDevices allKeys]) {
+    NSMutableDictionary *singleDevice= [[NSMutableDictionary alloc] init];
     GCKDevice *device = self.currentDevices[key];
     singleDevice[@"id"] = key;
     singleDevice[@"name"] = device.friendlyName;


### PR DESCRIPTION
This is to fix the duplicated scanned devices on iOS.

**This was the issue I was having when I received the scanned devices:**

![screen shot 2016-11-18 at 3 51 07 am](https://cloud.githubusercontent.com/assets/10192761/20429466/b27558a6-ad43-11e6-8840-3b6aa7b16268.png)

**After adding the the fix it is now able to correctly reference other devices:**

![screen shot 2016-11-18 at 4 00 42 am](https://cloud.githubusercontent.com/assets/10192761/20429500/f1de36ac-ad43-11e6-803d-188a76e0177f.png)
